### PR TITLE
Tweaks for accounts/plans

### DIFF
--- a/e2e/cypress/integration/ordering.ts
+++ b/e2e/cypress/integration/ordering.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-describe('Ordering products', { testIsolation: false }, () => {
+describe('Ordering products', () => {
     it('can place an order', () => {
         localStorage.removeItem('221:shoppingCart');
         cy.intercept('/rest/v1/account_product/available').as('availableProducts');
@@ -9,17 +9,13 @@ describe('Ordering products', { testIsolation: false }, () => {
         cy.wait('@availableProducts', {'timeout':10000});
         cy.get('.productGrid .purchaseButton').contains('Purchase').click();
         cy.get('#shoppingCartButton').should('be.visible');
-    });
 
-    it('cart contains the purchased product', () => {
         cy.get('#shoppingCartButton').click();
         cy.url().should('include', '/account/cart');
         cy.get('.mat-table tbody tr')
             .and('contain', 'Runbox Test')
             .and('contain', '13.37 EUR');
-    });
 
-    it('can select a payment method and pay', () => {
         cy.contains('mat-expansion-panel-header', 'Other payment methods').click();
         cy.get('button#payDirectly').click();
         cy.url().should('include', '/account/receipt');
@@ -30,11 +26,11 @@ describe('Ordering products', { testIsolation: false }, () => {
 
         cy.get('#shoppingCartButton').should('not.exist');
 
-        cy.get('.productGrid .purchaseButton').contains('Purchase').click();
+        cy.get('.productGrid .purchaseButton').contains('Add product').click();
         cy.get('#shoppingCartButton').should('be.visible');
         cy.get('#shoppingCartButton .mat-badge-content').should('contain', '1');
 
-        cy.get('.productGrid .purchaseButton').contains('Purchase').click();
+        cy.get('.productGrid .purchaseButton').contains('Add product').click();
         cy.get('#shoppingCartButton .mat-badge-content').should('contain', '1');
 
         cy.get('#shoppingCartButton').click();

--- a/src/app/account-app/account-product.component.html
+++ b/src/app/account-app/account-product.component.html
@@ -48,8 +48,8 @@
           <span *ngIf="me.is_trial">Subscribe</span>
           <span *ngIf="!me.is_trial && me.subscription === undefined">Purchase</span>
           <span *ngIf="!me.is_trial && p.pid == me.subscription">Renew</span>
-          <span *ngIf="!me.is_trial && p.quotas.Disk.quota > current_sub.quotas.Disk.quota">Upgrade</span>
-          <span *ngIf="!me.is_trial && p.quotas.Disk.quota < current_sub.quotas.Disk.quota">Downgrade</span>
+          <span *ngIf="!me.is_trial && is_upgrade">Upgrade</span>
+          <span *ngIf="!me.is_trial && is_downgrade">Downgrade</span>
           for {{ currency || "USD" }} {{ p.price | number:'1.2-2' }}
         </button>
         <ng-template #unpurchase>

--- a/src/app/account-app/account-product.component.ts
+++ b/src/app/account-app/account-product.component.ts
@@ -44,6 +44,8 @@ export class ProductComponent implements OnInit {
 
     over_quota = [];
     addon_usages = [];
+    is_upgrade = false;
+    is_downgrade = false;
 
     constructor(
         private cart: CartService,
@@ -58,10 +60,26 @@ export class ProductComponent implements OnInit {
         this.allow_multiple = this.p.type === 'addon';
         this.over_quota = this.check_over_quota();
         this.addon_usages = this.get_addon_usages();
-    
+        this.check_up_down_grade();
+
         this.rmmapi.me.subscribe(me => {
             this.me = me;
         });
+    }
+
+    // More or less disk space than the existing subscription?
+    check_up_down_grade() {
+        if (this.p && this.p.quotas && this.p.quotas.Disk
+            && this.current_sub && this.current_sub.quotas
+            && this.current_sub.quotas.Disk) {
+            // Don't set either if quota the same !
+            if (this.p.quotas.Disk.quota > this.current_sub.quotas.Disk.quota) {
+                this.is_upgrade = true;
+            }
+            if (this.p.quotas.Disk.quota < this.current_sub.quotas.Disk.quota) {
+                this.is_downgrade = true;
+            }
+        }
     }
 
     // OverQuota for displayed product, if any of the limits have been hit

--- a/src/app/account-app/account-upgrades.component.ts
+++ b/src/app/account-app/account-upgrades.component.ts
@@ -85,7 +85,9 @@ export class AccountUpgradesComponent implements OnInit {
             this.subs_special.next(subs_special);
             this.subs_special.complete();
 
-            this.subaccounts.next(products.filter(p => p.subtype === 'subaccount'));
+            const subaccounts = products.filter(p => p.subtype === 'subaccount');
+            subaccounts.sort((a,b) => a.sub_product_quota.Disk.quota - b.sub_product_quota.Disk.quota);
+            this.subaccounts.next(subaccounts);
             this.emailaddons.next(products.filter(p => p.subtype === 'emailaddon'));
 
             this.subaccounts.complete();

--- a/src/app/account-app/product.ts
+++ b/src/app/account-app/product.ts
@@ -37,6 +37,7 @@ export class Product {
     price:       number;
     currency:    string;
     quotas:      QuotaEntryMap;
+    sub_product_quota: QuotaEntryMap;
 
     constructor(properties: any) {
         // eslint-disable-next-line guard-for-in


### PR DESCRIPTION
* Fix ordering tests (should order an addon not main product for quantity testing)
* Fix upgrade/downgrade buttons (errors in console when data not loaded yet)
* Add sorting of subaccounts (needs backend merge)